### PR TITLE
Use tox instead of calling pretty_tox.sh directly

### DIFF
--- a/sos-ci/ansible/tasks/run_tempest.yml
+++ b/sos-ci/ansible/tasks/run_tempest.yml
@@ -9,6 +9,6 @@
 
   - name: run tempest
     sudo: no
-    shell: tools/pretty_tox.sh volume | tee -a console.log.out
+    shell: tox -e all -- volume | tee -a console.log.out
     args:
       chdir: /opt/stack/tempest


### PR DESCRIPTION
This commit replaces the use of pretty_tox directly (which is just a
testr wrapper) with calling tox which includes all of the python setup
steps.
