### PR TITLE
Add iniparse to requirements and sort alphabetical.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ansible
+iniparse
 paramiko>=1.13.0
 scp>=0.8.0
-ansible


### PR DESCRIPTION
Looks like the current requirements is missing iniparse.

```
$ python os_ci.py --help
Traceback (most recent call last):
  File "os_ci.py", line 14, in <module>
    from iniparse import INIConfig
ImportError: No module named iniparse
```
