### PR TITLE
Fix: Recheck datadir

### DIFF
--- a/sos-ci.conf.sample
+++ b/sos-ci.conf.sample
@@ -5,7 +5,7 @@ gerrit_port = 29418
 project_name = openstack/cinder
 ci_name = sos-changeme-dsvm-full
 ci_account = my-ci-account
-recheck_string = 'recheck my-ci-name'
+recheck_string = recheck
 
 [Ansible]
 ansible_dir = /path/to/my/ansible/playbooks

--- a/sos-ci/os_ci.py
+++ b/sos-ci/os_ci.py
@@ -177,8 +177,9 @@ class JobThread(Thread):
                     os.mkdir(results_dir)
                 except OSError:
                     if not os.path.isdir(results_dir):
-                        logger.error('Unable to create data dir for: \n%s',
-                                     event)
+                        logger.error('Unable to create data dir '
+                                     'at %(resdir)s for: \n%(ev)s',
+                                     {'resdir': results_dir, 'ev': event})
                     # data dir already exists, this is a recheck
 
                 try:

--- a/sos-ci/os_ci.py
+++ b/sos-ci/os_ci.py
@@ -173,7 +173,13 @@ class JobThread(Thread):
 
                 ref_name = patchset_ref.replace('/', '-')
                 results_dir = DATA_DIR + '/' + ref_name
-                os.mkdir(results_dir)
+                try:
+                    os.mkdir(results_dir)
+                except OSError:
+                    if not os.path.isdir(results_dir):
+                        logger.error('Unable to create data dir for: \n%s',
+                                     event)
+                    # data dir already exists, this is a recheck
 
                 try:
                     commit_id, success, output = \


### PR DESCRIPTION
Hi John!
This basically does two things:
1) Set the conf.sample recheck string as defined in http://ci.openstack.org/third_party.html to _recheck_. This can still be changed to e.g. _recheck myci-name_ but on the one hand removes the ' ' issue and on the other hand is conforming to infra-reqs.
2) Handles the data dir creation, this crashes in the last commit version as the dir already exists when running a recheck. Not this case is caught, checked further, and reports to the log in case of issues. I ran this setup on my ci-sandbox instance.
Cheers
Silvan
